### PR TITLE
Allow to trigger events from outside

### DIFF
--- a/src/function/init.js
+++ b/src/function/init.js
@@ -28,6 +28,7 @@ function($, emojione, blankImg, slice, css_class, emojioneSupportMode, trigger, 
     return function(self, source, options) {
         //calcElapsedTime('init', function() {
         options = getOptions(options);
+        self.triggerEvent  = trigger;
         self.sprite = options.sprite && emojioneSupportMode < 3;
         self.inline = options.inline === null ? source.is("INPUT") : options.inline;
         self.shortnames = options.shortnames;


### PR DESCRIPTION
Assigned function 'trigger' to self.triggerEvent

Example of usage:

```javascript

var triggerChange = function(){
                    self.triggerEvent(self, 'change', [self.editor]);
                    source.trigger("change");
                }
                var source = $element.emojioneArea({
                    hideSource        : false, // hide source element after binding
                    autoHideFilters   : false,
                    pickerPosition: "bottom",
                    inline: null,
                    events: {
                         keyup: function (editor, event) {
                                   triggerChange();
                          }
                    }
                });
                var self = source.data('emojioneArea');

```