### PR TITLE
Emojione mapUnicodeToShort() returns different alt text to jsEscapeMap

### DIFF
--- a/src/function/unicodeTo.js
+++ b/src/function/unicodeTo.js
@@ -9,7 +9,15 @@ function(emojione, uniRegexp, emojioneSupportMode, getTemplate) {
         return str.replace(uniRegexp, function(unicodeChar) {
             var map = emojione[(emojioneSupportMode === 0 ? 'jsecapeMap' : 'jsEscapeMap')];
             if (typeof unicodeChar !== 'undefined' && unicodeChar in map) {
-                return getTemplate(template, map[unicodeChar], emojione.toShort(unicodeChar));
+                if (emojioneSupportMode > 3) {
+                    var fname = map[unicodeChar];
+                    var mappedUnicode = emojione.mapUnicodeToShort();
+                    var shortcode = mappedUnicode[fname];
+
+                    return shortnameTo(shortcode, template);
+                } else {
+                    return getTemplate(template, map[unicodeChar], emojione.toShort(unicodeChar));
+                }
             }
             return unicodeChar;
         });


### PR DESCRIPTION
I'm using `saveEmojisAs: "shortname"` and `shortnames: true`. If I add 👩‍🏫 using the picker, then the `alt` text for the image uses the `&zwj;` syntax (using the `shortcodeTo` function). This is then turned into the `:woman_teacher:` shortcode (as expected).

However, if I edit the record I just created, it ends up using the `unicodeTo` function - which derives the `alt` text from the `jsEscapeMap` array. This version _doesn't_ include the `&zwj;` syntax. So when I save the output to the databases it ends up being `:school::female_sign:` instead of `:woman_teacher:`.

Looking at Emojione:

https://github.com/emojione/emojione/blob/168b9e06bf97ffe44eb35007b5971948d35600a2/lib/js/emojione.js#L315

They use `jsEscapeMap` then do a final lookup with `mapUnicodeToShort()`. So I've implemented a similar idea in `unicodeTo` (which ends up calling `shortcodeTo`). 

I don't know if there's a better way to do this (my javascript skills aren't that great). What do you think?