### PR TITLE
Added crossorigin="anonymous"

### DIFF
--- a/src/function/init.js
+++ b/src/function/init.js
@@ -38,8 +38,8 @@ function($, emojione, blankImg, slice, css_class, emojioneSupportMode, invisible
         self.shortnames = options.shortnames;
         self.saveEmojisAs = options.saveEmojisAs;
         self.standalone = options.standalone;
-        self.emojiTemplate = '<img alt="{alt}" class="emojione' + (self.sprite ? '-{uni}" src="' + blankImg + '"/>' : 'emoji" src="{img}"/>');
-        self.emojiTemplateAlt = self.sprite ? '<i class="emojione-{uni}"/>' : '<img class="emojioneemoji" src="{img}"/>';
+        self.emojiTemplate = '<img alt="{alt}" class="emojione' + (self.sprite ? '-{uni}" src="' + blankImg + '" crossorigin="anonymous"/>' : 'emoji" src="{img}" crossorigin="anonymous"/>');
+        self.emojiTemplateAlt = self.sprite ? '<i class="emojione-{uni}"/>' : '<img class="emojioneemoji" src="{img}" crossorigin="anonymous"/>';
         self.emojiBtnTemplate = '<i class="emojibtn" role="button" data-name="{name}" title="{friendlyName}">' + self.emojiTemplateAlt + '</i>';
         self.recentEmojis = options.recentEmojis && supportsLocalStorage();
 
@@ -172,7 +172,7 @@ function($, emojione, blankImg, slice, css_class, emojioneSupportMode, invisible
                 items = shortnameTo(items,
                     self.sprite ?
                         '<i class="emojibtn" role="button" data-name="{name}" title="{friendlyName}"><i class="emojione-{uni}"></i></i>' :
-                        '<i class="emojibtn" role="button" data-name="{name}" title="{friendlyName}"><img class="emojioneemoji lazy-emoji" data-src="{img}"/></i>',
+                        '<i class="emojibtn" role="button" data-name="{name}" title="{friendlyName}"><img class="emojioneemoji lazy-emoji" data-src="{img}" crossorigin="anonymous"/></i>',
                     true).split('|').join('');
 
                 category.html(items);


### PR DESCRIPTION
` crossorigin="anonymous"` is necessary for PWAs since the emoji assets fetched will need to be cached for a smooth user experience, unfortunately the assets are considered as **Opapue Responses** since they're from a 3rd Party origin, hence the need for ` crossorigin="anonymous"`

_References_
https://cloudfour.com/thinks/when-7-kb-equals-7-mb
https://developers.google.com/web/tools/workbox/guides/handle-third-party-requests
https://stackoverflow.com/a/39109790
https://stackoverflow.com/a/46435922