### PR TITLE
Added crossorigin='anonymous'

### DIFF
--- a/src/emojionearea.js
+++ b/src/emojionearea.js
@@ -35,7 +35,7 @@ function($, EmojioneArea, getDefaultOptions, htmlFromText, blankImg, emojioneSup
 
         var self = this, pseudoSelf = {
             shortnames: (options && typeof options.shortnames !== 'undefined' ? options.shortnames : true),
-            emojiTemplate: '<img alt="{alt}" class="emojione' + (options && options.sprite && emojioneSupportMode < 3 ? '-{uni}" src="' + blankImg : 'emoji" src="{img}') + '"/>'
+            emojiTemplate: '<img alt="{alt}" class="emojione' + (options && options.sprite && emojioneSupportMode < 3 ? '-{uni}" src="' + blankImg : 'emoji" src="{img}') + '" crossorigin="anonymous"/>'
         };
 
         loadEmojione(options);

--- a/src/emojionearea.js
+++ b/src/emojionearea.js
@@ -35,7 +35,7 @@ function($, EmojioneArea, getDefaultOptions, htmlFromText, blankImg, emojioneSup
 
         var self = this, pseudoSelf = {
             shortnames: (options && typeof options.shortnames !== 'undefined' ? options.shortnames : true),
-            emojiTemplate: '<img alt="{alt}" class="emojione' + (options && options.sprite && emojioneSupportMode < 3 ? '-{uni}" src="' + blankImg : 'emoji" src="{img}') + '" crossorigin="anonymous"/>'
+            emojiTemplate: '<img alt="{alt}" class="emojione' + (options && options.sprite && emojioneSupportMode < 3 ? '-{uni}" src="' + blankImg : 'emoji" src="{img}') + '" crossorigin />'
         };
 
         loadEmojione(options);


### PR DESCRIPTION
Required by PWAs (ServiceWorker caching system) to prevent asset bloating, currently caching the emoji png responses alone is over 1GB for all the emojis. Adding crossorigin='anonymous' mitigates the intentional bloating it does nothing else, please merge so PWA devs can benefit from this awesome lib.

_References_
https://cloudfour.com/thinks/when-7-kb-equals-7-mb/